### PR TITLE
Linking Location and Earthquake searches

### DIFF
--- a/src/main/java/earthquakes/services/EarthquakeQueryService.java
+++ b/src/main/java/earthquakes/services/EarthquakeQueryService.java
@@ -33,8 +33,8 @@ public class EarthquakeQueryService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String uri = "https://earthquake.usgs.gov/fdsnws/event/1/query";
-        double ucsbLat = 34.4140;
-        double ucsbLong = -119.8489;
+        //double ucsbLat = 34.4140;
+        //double ucsbLong = -119.8489;
         String params = String.format("?format=geojson&minmagnitude=%d&maxradiuskm=%d&latitude=%f&longitude=%f&location=",
 				      minmag,distance,lat,lon);
 

--- a/src/main/resources/templates/earthquakes/results.html
+++ b/src/main/resources/templates/earthquakes/results.html
@@ -12,10 +12,6 @@
 
         <h1>Earthquake Search Results</h1>
 
-        <!--<h2>JSON Results</h2>
-
-        <pre th:text="${json}">This is placeholder</pre>-->
-
 	<h2> Results</h2>
 	
         <table class = "table">

--- a/src/main/resources/templates/locations/results.html
+++ b/src/main/resources/templates/locations/results.html
@@ -17,13 +17,11 @@
         <table class = "table">
           <thead>
             <tr>
-	      <!--<th>Title</th>-->
 	      <th>Location</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-	      <!--<td><a th:href="${featureCollection.metadata.url}" th:text="${featureCollection.metadata.title}"></a></td>-->
 	      <td th:text="${locSearch.location}"></td>
             </tr>
           </tbody>
@@ -33,6 +31,7 @@
         <table class = "table">
           <thead>
             <tr>
+	      <th>Get Earthquakes</th>
               <th>Place ID</th>
               <th>Latitude</th>
               <th>Longitude</th>
@@ -42,6 +41,7 @@
           </thead>
           <tbody>
             <tr th:each="p: ${places}">
+	      <td><a th:href="@{/earthquakes/search/(lat=${p.lat},lon=${p.lon},location=${p.display_name})}">Get Earthquakes</a></td>
 	      <td th:text="${p.place_id}"></td>
 	      <td th:text="${p.lat}"></td>
               <td th:text="${p.lon}"></td>


### PR DESCRIPTION
In this PR:
- adding a link in locations search results
- this automatically enters lat and lon into earthquake search form
- and displays corresponding results